### PR TITLE
Adding a base structure for the monitor service

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,0 +1,17 @@
+# Simple environment image to build the go openbao monitor
+# The build result should be in the output folder
+# Example: docker build --target bin --output bin/ -f ./build/Dockerfile .
+
+FROM golang:1.24.1-bookworm AS build
+
+WORKDIR /src
+
+COPY . .
+
+RUN go mod download
+
+RUN go build -o /out/baomon .
+
+FROM scratch AS bin
+
+COPY --from=build /out/baomon /

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/michel-thebeau-WR/openbao-manager-go/baomon
+
+go 1.18

--- a/main.go
+++ b/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Print("Baomon says \"hello world!\"\n")
+}

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -1,0 +1,32 @@
+# Test image for go openbao monitor
+# Debian image with openbao and go openbao monitor installed
+# Example command to build: docker build -f test/Dockerfile .
+
+FROM debian:stable-slim
+
+ENV PKG_LIST="mawk bash coreutils curl grep sed jq uuid-runtime golang wget"
+
+USER root
+
+# install packages
+RUN set -ex; \
+    apt-get update && apt-get install -y $PKG_LIST \
+    && apt-get clean && rm -r /var/lib/apt/lists/*
+
+# Download openbao
+RUN mkdir -p /tmp && \
+    wget -P /tmp/ https://github.com/openbao/openbao/releases/download/v2.1.0/bao_2.1.0_linux_amd64.deb && \
+    dpkg -i /tmp/bao_2.1.0_linux_amd64.deb
+
+# create a non-root user/group for openbao-manager
+RUN groupadd --gid 1000 manager \
+    && adduser --uid 1000 --gid 1000 manager \
+        --home /workdir --shell /bin/bash
+
+USER manager
+
+# Copy over go openbao monitor
+# Use the output folder used in the build
+COPY ./bin/baomon .
+
+CMD ["bash"]


### PR DESCRIPTION
Adding a basic development structure for the new monitor service. This includes a minimal go program, a build env image, and a test env image.

The build image will build the go program with the name "baomon". The test image will grab that image and create a test environment with openbao installed. Use "./baomon" to run the program.

Testing done:
- The go program builds successfully with "go build"
- The go program builds successfully with the build image
- The test image builds correctly with openbao and baomon installed.