### PR TITLE
Add Auth Token to the Config Module

### DIFF
--- a/config/server.go
+++ b/config/server.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"regexp"
 
 	"github.com/go-yaml/yaml"
 )
@@ -13,8 +14,21 @@ type URL struct {
 	Port int    `yaml:"port"`
 }
 
+type Token struct {
+	Duration int    `yaml:"duration"`
+	Key      string `yaml:"key"`
+}
+
 type MonitorConfig struct {
+	// A map value listing all DNS names
+	// Key: Domain name
+	// Value: URL. consisting of host address and port number
 	DNSnames map[string]URL `yaml:"IncludeInCluster"`
+
+	// A map value listing all authentication tokens
+	// Key: release id
+	// Value: Token. consisting of lease duration and the token key
+	Tokens map[string]Token `yaml:"Tokens"`
 }
 
 func (s *MonitorConfig) ReadYAMLMonitorConfig(in io.Reader) error {
@@ -33,6 +47,25 @@ func (s *MonitorConfig) ReadYAMLMonitorConfig(in io.Reader) error {
 		// If either Host or Port number is empty, then the domain entry is invalid
 		if url.Host == "" || url.Port == 0 {
 			return fmt.Errorf("the domain entry %v in config InvludeInCluster is invalid", domain_name)
+		}
+	}
+
+	// Validate YAML input for Tokens
+	rootExists := false
+	r, _ := regexp.Compile("[sbr][.][a-zA-Z0-9]{24,}")
+	for releaseID, token := range s.Tokens {
+		if token.Duration == 0 {
+			// There can only be one root token
+			if rootExists {
+				return fmt.Errorf("there are two or more root tokens listed")
+			} else {
+				rootExists = true
+			}
+		}
+		// Token key should have s, b, or r as the first character, and . as the second.
+		// The body of the token (key[2:]) should be 24 characters or more
+		if !r.MatchString(token.Key) {
+			return fmt.Errorf("the token with release id %v has wrong key format", releaseID)
 		}
 	}
 

--- a/config/test_examples/exampleAuthToken1.yaml
+++ b/config/test_examples/exampleAuthToken1.yaml
@@ -1,0 +1,7 @@
+Tokens:
+  exampleToken:
+    duration: 0
+    key: s.ACurrectRootTokenWithCorrectFormat
+  anotherExampleToken:
+    duration: 1000
+    key: b.AnotherKeyThatIsNotARootToken

--- a/config/test_examples/exampleAuthToken2.yaml
+++ b/config/test_examples/exampleAuthToken2.yaml
@@ -1,0 +1,4 @@
+Tokens:
+  wrongFormatToken:
+    duration: 0
+    key: c.KeyWithWrongFirstCharacter

--- a/config/test_examples/exampleAuthToken3.yaml
+++ b/config/test_examples/exampleAuthToken3.yaml
@@ -1,0 +1,4 @@
+Tokens:
+  wrongFormatToken:
+    duration: 0
+    key: bbKeyWithWrongSecondCharacter

--- a/config/test_examples/exampleAuthToken4.yaml
+++ b/config/test_examples/exampleAuthToken4.yaml
@@ -1,0 +1,4 @@
+Tokens:
+  wrongFormatToken:
+    duration: 0
+    key: r.KeyThatIsTooShort


### PR DESCRIPTION
Adding an Authentication token section in the config module. 
This stores the authentication token info

Testing done:
 - build with the build container
 - test each of the new yaml files in test_example. Only the first one (exampleAuthToken1.yaml) should pass.