### PR TITLE
add generation of certificates for test

### DIFF
--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -6,7 +6,15 @@
 
 # Test image for go openbao monitor
 # Debian image with openbao and go openbao monitor installed
-# Example command to build: docker build -f test/Dockerfile .
+# Example commands to build:
+#   test/scripts/gen_certs.sh
+#   docker build -f test/Dockerfile .
+#
+# gen_certs.sh only needs to be run once, with the CA cert expiry of
+# 10 years and the server/client certs expiring in 30 days.
+# gen_certs.sh will not regenerate the CA cert if it exists, so that
+# testing with a web browser doesn't require replacing the trusted
+# certificate.
 
 FROM debian:stable-slim
 
@@ -48,6 +56,7 @@ RUN echo "source /etc/bash_completion" >> /workdir/.bashrc
 # Copy testing files
 COPY ./bin/OpenBaoCA/ /workdir/OpenBaoCA/
 COPY ./bin/OpenBaoServerCert/ /workdir/OpenBaoServerCert/
+COPY ./bin/OpenBaoClientCert/ /workdir/OpenBaoClientCert/
 COPY ./test/* /workdir/
 
 CMD ["bash"]

--- a/test/scripts/gen_certs.sh
+++ b/test/scripts/gen_certs.sh
@@ -1,0 +1,110 @@
+#!/bin/bash
+
+#
+# Copyright (c) 2025 Wind River Systems, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+function usage {
+    (
+    echo "Usage: "
+    echo "  One optional parameter pair:"
+    echo "    --certbase <dirname>"
+    echo "The default certbase is ./bin, matching the output of build"
+    ) >&2
+}
+
+if [ $# -ne 0 -a $# -ne 2 ]; then
+    usage
+    exit 1
+fi
+
+if [ "$1" != "--certbase" ]; then
+    CERTBASE=bin
+else
+    if [ -d "$2" ]; then
+        CERTBASE="$2"
+    else
+        echo "'$2' is not a directory" >&2
+        exit 1
+    fi
+fi
+
+CAPATH="${CERTBASE}/OpenBaoCA"
+SERVERPATH="${CERTBASE}/OpenBaoServerCert"
+CLIENTPATH="${CERTBASE}/OpenBaoClientCert"
+mkdir -p "$CAPATH" "$SERVERPATH" "$CLIENTPATH"
+
+# for the benefit of the tester, do not recreate their CA
+if [ ! -f "${CAPATH}/ca.crt" -o ! -f "${CAPATH}/ca.key" ]; then
+    # generate the CA key
+    openssl ecparam -name prime256v1 -genkey -noout \
+        -out "${CAPATH}/ca.key"
+
+    # generate a CA cert for test that is valid forever (10 years)
+    keyUsage="critical, keyCertSign, digitalSignature, keyEncipherment"
+    openssl req -new -x509 -sha256 \
+        -key "${CAPATH}/ca.key" \
+        -out "${CAPATH}/ca.crt" \
+        -days 3650 \
+        -addext "keyUsage = $keyUsage" \
+        -subj '/CN=OpenBao Test CA/C=CA/O=StarlingX'
+fi
+
+# generate private key for the openbao server
+openssl genrsa -out "${SERVERPATH}/tls.key" 2048
+
+# generate certificate signing request for server
+openssl req -new \
+    -key "${SERVERPATH}/tls.key" \
+    -out "${SERVERPATH}/server.csr" \
+    -addext "subjectAltName = DNS:OpenBao, DNS:localhost, IP:127.0.0.1, IP:0.0.0.0" \
+    -addext "keyUsage = critical, digitalSignature, keyEncipherment" \
+    -subj '/CN=OpenBao Test Server/C=CA/O=StarlingX'
+
+# work around bug in copying extensions when signing the crt
+cat <<EOF > "${SERVERPATH}/ssl-extensions-x509.cnf"
+[v3_ca]
+basicConstraints = CA:FALSE
+keyUsage = critical, digitalSignature, keyEncipherment
+subjectAltName = DNS:OpenBao, DNS:localhost, IP:127.0.0.1, IP:0.0.0.0
+EOF
+
+# sign the csr using CA (create the server cert)
+openssl x509 -req -in "${SERVERPATH}/server.csr" \
+    -CA "${CAPATH}/ca.crt" -CAkey "${CAPATH}/ca.key" \
+    -CAcreateserial \
+    -out "${SERVERPATH}/tls.crt" \
+    -days 30 \
+    -extensions v3_ca \
+    -extfile "${SERVERPATH}/ssl-extensions-x509.cnf"
+
+# generate private key for the baomon client
+openssl genrsa -out "${CLIENTPATH}/tls.key" 2048
+
+# generate certificate signing request for client
+openssl req -new -key "${CLIENTPATH}/tls.key" \
+    -out "${CLIENTPATH}/client.csr" \
+    -addext "keyUsage = critical, digitalSignature" \
+    -addext "extendedKeyUsage = critical, clientAuth" \
+    -subj '/CN=OpenBao Test Client/C=CA/O=StarlingX'
+
+# work around bug in copying extensions when signing the crt
+cat <<EOF > "${CLIENTPATH}/ssl-extensions-x509.cnf"
+[v3_ca]
+basicConstraints = CA:FALSE
+keyUsage = critical, digitalSignature
+extendedKeyUsage = critical, clientAuth
+EOF
+
+# sign the csr using CA (create the server cert)
+openssl x509 -req -in "${CLIENTPATH}/client.csr" \
+    -CA "${CAPATH}/ca.crt" -CAkey "${CAPATH}/ca.key" \
+    -CAcreateserial \
+    -out "${CLIENTPATH}/tls.crt" \
+    -days 30 \
+    -extensions v3_ca \
+    -extfile "${CLIENTPATH}/ssl-extensions-x509.cnf"
+
+

--- a/test/testConfig.yaml
+++ b/test/testConfig.yaml
@@ -9,8 +9,8 @@ IncludeInCluster:
     host: "Openbao"
     port: 8200
 CACert: "/workdir/OpenBaoCA/ca.crt"
-ClientCert: "/workdir/OpenBaoCA/tls.crt"
-ClientKey: "/workdir/OpenBaoCA/tls.key"
+ClientCert: "/workdir/OpenBaoClientCert/tls.crt"
+ClientKey: "/workdir/OpenBaoClientCert/tls.key"
 logPath: "/workdir/openbao_monitor.log"
 logLevel: "DEBUG"
 WaitInterval: 5


### PR DESCRIPTION
Provides a script the developer can use to generate certificates that are used within the test container.

Tox/bashate is run on the script.