### PR TITLE
Reorganize config/default entries

### DIFF
--- a/commands/run.go
+++ b/commands/run.go
@@ -47,8 +47,8 @@ attempt to unseal.`,
 				}
 			}
 
-			clientMap := make(map[string]*openbao.Client, len(globalConfig.DNSnames))
-			for host := range maps.Keys(globalConfig.DNSnames) {
+			clientMap := make(map[string]*openbao.Client, len(globalConfig.OpenbaoAddresses))
+			for host := range maps.Keys(globalConfig.OpenbaoAddresses) {
 				slog.Debug(fmt.Sprintf("Creating client for host %v", host))
 				newClient, err := globalConfig.SetupClient(host)
 				if err != nil {

--- a/config/validate.go
+++ b/config/validate.go
@@ -10,11 +10,12 @@ import (
 )
 
 func (configInstance MonitorConfig) validateDNS() error {
-	for domain_name, url := range configInstance.DNSnames {
-		// If either Host or Port number is empty, then the domain entry is invalid
-		if url.Host == "" || url.Port == 0 {
+	for domain_name, url := range configInstance.OpenbaoAddresses {
+		// If Host is empty, then the domain entry is invalid
+		// The ports will always at least have the default value of 8200
+		if url.Host == "" {
 			return fmt.Errorf(
-				"the domain entry %v in config InvludeInCluster is invalid", domain_name)
+				"the domain entry %v in OpenbaoAddresses is invalid", domain_name)
 		}
 	}
 

--- a/test/config/test_examples/exampleServer1.yaml
+++ b/test/config/test_examples/exampleServer1.yaml
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-IncludeInCluster:
+OpenbaoAddresses:
   controller-0:
     host: controller-0
     port: 4203

--- a/test/config/test_examples/exampleServer2.yaml
+++ b/test/config/test_examples/exampleServer2.yaml
@@ -4,4 +4,4 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-IncludeInCluster:
+OpenbaoAddresses:

--- a/test/config/test_examples/exampleServer3.yaml
+++ b/test/config/test_examples/exampleServer3.yaml
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-IncludeInCluster:
+OpenbaoAddresses:
   controller-0:
     host: 
     port: 

--- a/test/testConfig.yaml
+++ b/test/testConfig.yaml
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-IncludeInCluster:
+OpenbaoAddresses:
   controller-0:
     host: "Openbao"
     port: 8200


### PR DESCRIPTION
Reorganizing monitor config entries & default values:
- Renamed "IncludeInCluster" and "DNSnames" to "OpenbaoAddresses
- Renamed "URL" to "OpenbaoAddress"
- Added entries for K8s related configs (Namespace, Name prefixes, address suffixes)
- Added default port number entry
- Default log file changed to stdout

Tests Done:
- Unit tests for new names
- Observe correct default entries