### PR TITLE
Add linting

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -19,6 +19,16 @@ RUN go mod download
 
 RUN go mod tidy
 
+# run linting
+
+RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s v2.1.6
+
+ADD ./build/lintConfig.yaml /src/.golangci.yaml
+
+RUN ./bin/golangci-lint migrate -c /src/.golangci.yaml
+
+RUN ./bin/golangci-lint run
+
 RUN go build -o /out/baomon .
 
 # save the module sources

--- a/build/lintConfig.yaml
+++ b/build/lintConfig.yaml
@@ -1,0 +1,15 @@
+linters-settings:
+  gocyclo:
+    min-complexity: 7
+  goconst:
+    min-occurrences: 2
+  gomoddirectives:
+    replace-local: true
+
+linters:
+  enable-all: true
+  disable:
+    - interfacer
+    - dupl
+    - depguard
+    - prealloc


### PR DESCRIPTION
Add automatic linting in the build container. The container will now run linting from https://github.com/golangci/golangci-lint before building the executable. Associated config file is also added.

Note: Had to add "replace-local: true" to ignore the "do not do local replace" error. Otherwise the local build will error there. I have not found a way to add the local packages without using the "replace ..." line.