### PR TITLE
Add option to disable linters

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -8,6 +8,8 @@
 # The build result should be in the output folder
 # Example: docker build --target bin --output bin/ -f ./build/Dockerfile .
 
+ARG WITH_LINTERS=0
+
 FROM golang:1.24.3-bullseye AS build
 
 WORKDIR /src
@@ -21,13 +23,12 @@ RUN go mod tidy
 
 # run linting
 
-RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s v2.1.6
-
 ADD ./build/lintConfig.yaml /src/.golangci.yaml
 
-RUN ./bin/golangci-lint migrate -c /src/.golangci.yaml
-
-RUN ./bin/golangci-lint run
+RUN if [ "$WITH_LINTERS" ]; then \
+    curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s v2.1.6 \
+    && ./bin/golangci-lint migrate -c /src/.golangci.yaml \
+    && ./bin/golangci-lint run; fi
 
 RUN go build -o /out/baomon .
 


### PR DESCRIPTION
Set WITH_LINTERS=1 to disable the linters.  Useful if the download is temporarily not working, or to save time (26s) when linting is not required.