### PR TITLE
debrand the monitor service

### DIFF
--- a/commands/health.go
+++ b/commands/health.go
@@ -5,15 +5,15 @@ import (
 	"fmt"
 	"log/slog"
 
-	openbao "github.com/openbao/openbao/api/v2"
+	clientapi "github.com/openbao/openbao/api/v2"
 	"github.com/spf13/cobra"
 )
 
-func checkHealth(dnshost string, client *openbao.Client) (*openbao.HealthResponse, error) {
-	slog.Debug(fmt.Sprintf("Attempting to check openbao health on host %v", dnshost))
+func checkHealth(dnshost string, client *clientapi.Client) (*clientapi.HealthResponse, error) {
+	slog.Debug(fmt.Sprintf("Attempting to check health on host %v", dnshost))
 	healthResult, err := client.Sys().Health()
 	if err != nil {
-		return nil, fmt.Errorf("error during call to openbao check health: %v", err)
+		return nil, fmt.Errorf("error during call to check health: %v", err)
 	}
 
 	slog.Debug("health check complete")
@@ -22,8 +22,8 @@ func checkHealth(dnshost string, client *openbao.Client) (*openbao.HealthRespons
 
 var healthCmd = &cobra.Command{
 	Use:                "health DNSHost",
-	Short:              "Check openbao health",
-	Long:               "Check the health status of the openbao server on the specified host",
+	Short:              "Check server health",
+	Long:               "Check the health status of the server on the specified host",
 	Args:               cobra.ExactArgs(1),
 	PersistentPreRunE:  setupCmd,
 	PersistentPostRunE: cleanCmd,
@@ -33,11 +33,11 @@ var healthCmd = &cobra.Command{
 		cmd.SilenceUsage = true
 		newClient, err := globalConfig.SetupClient(args[0])
 		if err != nil {
-			return fmt.Errorf("openbao health failed with error: %v", err)
+			return fmt.Errorf("server health failed with error: %v", err)
 		}
 		healthResult, err := checkHealth(args[0], newClient)
 		if err != nil {
-			return fmt.Errorf("openbao health failed with error: %v", err)
+			return fmt.Errorf("server health failed with error: %v", err)
 		}
 		healthPrint, err := json.MarshalIndent(healthResult, "", "  ")
 		if err != nil {

--- a/commands/init.go
+++ b/commands/init.go
@@ -12,7 +12,7 @@ import (
 	"log/slog"
 	"os"
 
-	openbao "github.com/openbao/openbao/api/v2"
+	clientapi "github.com/openbao/openbao/api/v2"
 	"github.com/spf13/cobra"
 )
 
@@ -20,26 +20,26 @@ var optFileStr string
 var secretShares int
 var secretThreshold int
 
-func initializeOpenbao(dnshost string, opts *openbao.InitRequest) error {
-	slog.Debug(fmt.Sprintf("Attempting the initialize openbao on host %v", dnshost))
+func initializeServer(dnshost string, opts *clientapi.InitRequest) error {
+	slog.Debug(fmt.Sprintf("Attempting the initialize the server %v", dnshost))
 	newClient, err := globalConfig.SetupClient(dnshost)
 	if err != nil {
 		return err
 	}
 
-	slog.Debug("Checking current openbao status")
+	slog.Debug("Checking current server status")
 	healthResult, err := checkHealth(dnshost, newClient)
 	if err != nil {
 		return err
 	}
 	if healthResult.Initialized {
-		return fmt.Errorf("openbao server on host %v is already initialized", dnshost)
+		return fmt.Errorf("The server on host %v is already initialized", dnshost)
 	}
 
 	slog.Debug("Running /sys/init")
 	response, err := newClient.Sys().Init(opts)
 	if err != nil {
-		return fmt.Errorf("error during call to openbao init: %v", err)
+		return fmt.Errorf("error during call to init: %v", err)
 	}
 
 	slog.Debug("/sys/init complete")
@@ -53,8 +53,8 @@ func initializeOpenbao(dnshost string, opts *openbao.InitRequest) error {
 
 var initCmd = &cobra.Command{
 	Use:   "init DNSHost",
-	Short: "Initialize openbao",
-	Long: `Initialize openbao server using the monitor configurations.
+	Short: "Initialize the server",
+	Long: `Initialize the server using the monitor configurations.
 The key shards returned from the initResponse will be stored in the monitor
 configurations.`,
 	Args:              cobra.ExactArgs(1),
@@ -67,13 +67,13 @@ configurations.`,
 
 		if (fileGiven && (secretSharesFlag || secretThresholdFlag)) ||
 			(!fileGiven && !(secretSharesFlag && secretThresholdFlag)) {
-			fmt.Fprintf(os.Stderr, "The options for openbao init must be set by one of:\n")
+			fmt.Fprintf(os.Stderr, "The options for init must be set by one of:\n")
 			fmt.Fprintf(os.Stderr, "utilizing an option file using --file, or\n")
 			fmt.Fprintf(os.Stderr, "--secret-shares and -- secret-threshold\n")
 			return fmt.Errorf("failed due to invalid or missing options")
 		}
 
-		var opts openbao.InitRequest
+		var opts clientapi.InitRequest
 		if fileGiven {
 			optFileReader, err := os.ReadFile(optFileStr)
 			if err != nil {
@@ -96,21 +96,21 @@ configurations.`,
 			opts.SecretShares = secretShares
 			opts.SecretThreshold = secretThreshold
 		}
-		slog.Debug(fmt.Sprintf("Parsing init option successful. Attempting to run openbao init on host %v", args[0]))
+		slog.Debug(fmt.Sprintf("Parsing init option successful. Attempting to run init on host %v", args[0]))
 		cmd.SilenceUsage = true
-		err := initializeOpenbao(args[0], &opts)
+		err := initializeServer(args[0], &opts)
 		if err != nil {
-			return fmt.Errorf("openbao init failed with error: %v", err)
+			return fmt.Errorf("Init failed with error: %v", err)
 		}
-		slog.Info(fmt.Sprintf("Openbao init successful for host %v", args[0]))
-		fmt.Print("Openbao init complete\n")
+		slog.Info(fmt.Sprintf("Init successful for host %v", args[0]))
+		fmt.Print("Init complete\n")
 		return nil
 	},
 	PersistentPostRunE: cleanCmd,
 }
 
 func init() {
-	initCmd.Flags().StringVarP(&optFileStr, "file", "f", "", "A JSON file containing the options for openbao init")
+	initCmd.Flags().StringVarP(&optFileStr, "file", "f", "", "A JSON file containing the options for init")
 	initCmd.Flags().IntVar(&secretShares, "secret-shares", 0, "The number of shares to split the root key into.")
 	initCmd.Flags().IntVar(&secretThreshold, "secret-threshold", 0, "The number of shares required to reconstruct the root key.")
 	RootCmd.AddCommand(initCmd)

--- a/commands/root.go
+++ b/commands/root.go
@@ -30,13 +30,13 @@ func getK8sConfig() (*rest.Config, error) {
 	var err error = nil
 	slog.Debug("Setting up kubernetes config...")
 	if useInClusterConfig {
-		slog.Debug("Baomon is running inside the kubernetes cluster. Using in-cluster configs.")
+		slog.Debug("The monitor is running inside the kubernetes cluster. Using in-cluster configs.")
 		config, err = rest.InClusterConfig()
 		if err != nil {
 			return nil, err
 		}
 	} else {
-		slog.Debug(fmt.Sprintf("Baomon is running outside the kubernetes cluster. Using configs from %v", kubeConfigPath))
+		slog.Debug(fmt.Sprintf("The monitor is running outside the kubernetes cluster. Using configs from %v", kubeConfigPath))
 		config, err = clientcmd.BuildConfigFromFlags("", kubeConfigPath)
 		if err != nil {
 			return nil, err
@@ -85,7 +85,7 @@ func setupCmd(cmd *cobra.Command, args []string) error {
 	slog.Debug(fmt.Sprintf("Set log level: %v", logLevel))
 
 	// If useK8sConfig is set to true, then it will override the following configs:
-	// OpenbaoAddresses, Tokens, UnsealKeyShards
+	// ServerAddresses, Tokens, UnsealKeyShards
 	if useK8sConfig {
 		// create client config
 		config, err := getK8sConfig()
@@ -134,13 +134,13 @@ func cleanCmd(cmd *cobra.Command, args []string) error {
 
 var RootCmd = &cobra.Command{
 	Use:   "baomon",
-	Short: "A monitor service for managing Openbao in StarlingX",
-	Long:  `A monitor service for managing Openbao servers in StarlingX systems.`,
+	Short: "A monitor service for managing the secret servers",
+	Long:  `A monitor service for managing the secret servers`,
 }
 
 func Execute() {
 	if err := RootCmd.Execute(); err != nil {
-		slog.Error(fmt.Sprintf("Baomon failed with error: %v", err))
+		slog.Error(fmt.Sprintf("The monitor failed with error: %v", err))
 		if baoLogger != nil && logWriter != os.Stdout {
 			// If logging was setup on a file, print error separately to stderr as well.
 			fmt.Fprintln(os.Stderr, err)
@@ -153,9 +153,9 @@ func init() {
 	// Declarations for global flags
 	RootCmd.PersistentFlags().StringVar(&configFile, "config",
 		"/workdir/testConfig.yaml", "file path to the monitor config file")
-	RootCmd.PersistentFlags().BoolVar(&useK8sConfig, "k8s", false, "use openbao configs from kubernetes instead")
+	RootCmd.PersistentFlags().BoolVar(&useK8sConfig, "k8s", false, "use configs from kubernetes instead")
 	RootCmd.PersistentFlags().BoolVar(&useInClusterConfig, "in-cluster", true,
-		"Set this to true if baomon is run in a kubernetes pod")
+		"Set this to true if the monitor is run in a kubernetes pod")
 	RootCmd.PersistentFlags().StringVar(&kubeConfigPath, "kubeconfig", "/etc/kubernetes/admin.conf",
 		"The path for kubernetes config file (KUBECONFIG)")
 }

--- a/commands/unseal.go
+++ b/commands/unseal.go
@@ -7,12 +7,12 @@ import (
 	"strings"
 
 	baoConfig "github.com/michel-thebeau-WR/openbao-manager-go/baomon/config"
-	openbao "github.com/openbao/openbao/api/v2"
+	clientapi "github.com/openbao/openbao/api/v2"
 	"github.com/spf13/cobra"
 )
 
 // A single instance of unseal.
-func tryUnseal(keyShard baoConfig.KeyShards, client *openbao.Client) (*openbao.SealStatusResponse, error) {
+func tryUnseal(keyShard baoConfig.KeyShards, client *clientapi.Client) (*clientapi.SealStatusResponse, error) {
 	slog.Debug("Attempting unseal...")
 	key := keyShard.Key
 	UnsealResult, err := client.Sys().Unseal(key)
@@ -24,16 +24,16 @@ func tryUnseal(keyShard baoConfig.KeyShards, client *openbao.Client) (*openbao.S
 }
 
 // run unseal on all keys associated with dnshost until unsealed.
-func runUnseal(dnshost string, client *openbao.Client) (*openbao.SealStatusResponse, error) {
+func runUnseal(dnshost string, client *clientapi.Client) (*clientapi.SealStatusResponse, error) {
 	slog.Debug(fmt.Sprintf("Attempting to run unseal on host %v", dnshost))
 
-	slog.Debug("Checking if openbao is already unsealed")
+	slog.Debug("Checking if the server is already unsealed")
 	healthResult, err := checkHealth(dnshost, client)
 	if err != nil {
 		return nil, err
 	}
 	if !healthResult.Sealed {
-		return nil, fmt.Errorf("openbao server on host %v is already unsealed", dnshost)
+		return nil, fmt.Errorf("The server on host %v is already unsealed", dnshost)
 	}
 
 	tryCount := 1
@@ -49,7 +49,7 @@ func runUnseal(dnshost string, client *openbao.Client) (*openbao.SealStatusRespo
 				slog.Debug("Unseal complete.")
 				return UnsealResult, nil
 			}
-			slog.Debug(fmt.Sprintf("Openbao still sealed: threshold %v, progress %v", UnsealResult.T, UnsealResult.Progress))
+			slog.Debug(fmt.Sprintf("The server is still sealed: threshold %v, progress %v", UnsealResult.T, UnsealResult.Progress))
 			tryCount++
 		}
 	}
@@ -59,8 +59,8 @@ func runUnseal(dnshost string, client *openbao.Client) (*openbao.SealStatusRespo
 
 var unsealCmd = &cobra.Command{
 	Use:   "unseal DNSHost",
-	Short: "Unseal openbao",
-	Long: `Unseal openbao server hosted on DNSHost. It will use all
+	Short: "Unseal a server",
+	Long: `Unseal the server hosted on DNSHost. It will use all
 non-recovery keys with its name on it to unseal.`,
 	Args:               cobra.ExactArgs(1),
 	PersistentPreRunE:  setupCmd,
@@ -71,11 +71,11 @@ non-recovery keys with its name on it to unseal.`,
 		cmd.SilenceUsage = true
 		newClient, err := globalConfig.SetupClient(args[0])
 		if err != nil {
-			return fmt.Errorf("openbao unseal failed with error: %v", err)
+			return fmt.Errorf("unseal failed with error: %v", err)
 		}
 		UnsealResult, err := runUnseal(args[0], newClient)
 		if err != nil {
-			return fmt.Errorf("openbao unseal failed with error: %v", err)
+			return fmt.Errorf("unseal failed with error: %v", err)
 		}
 
 		UnsealPrint, err := json.MarshalIndent(UnsealResult, "", "  ")

--- a/config/validate.go
+++ b/config/validate.go
@@ -10,12 +10,12 @@ import (
 )
 
 func (configInstance MonitorConfig) validateDNS() error {
-	for domain_name, url := range configInstance.OpenbaoAddresses {
+	for domain_name, url := range configInstance.ServerAddresses {
 		// If Host is empty, then the domain entry is invalid
 		// The ports will always at least have the default value of 8200
 		if url.Host == "" {
 			return fmt.Errorf(
-				"the domain entry %v in OpenbaoAddresses is invalid", domain_name)
+				"the domain entry %v in ServerAddresses is invalid", domain_name)
 		}
 	}
 

--- a/test/config/test_examples/exampleServer1.yaml
+++ b/test/config/test_examples/exampleServer1.yaml
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-OpenbaoAddresses:
+ServerAddresses:
   controller-0:
     host: controller-0
     port: 4203

--- a/test/config/test_examples/exampleServer2.yaml
+++ b/test/config/test_examples/exampleServer2.yaml
@@ -4,4 +4,4 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-OpenbaoAddresses:
+ServerAddresses:

--- a/test/config/test_examples/exampleServer3.yaml
+++ b/test/config/test_examples/exampleServer3.yaml
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-OpenbaoAddresses:
+ServerAddresses:
   controller-0:
     host: 
     port: 

--- a/test/testConfig.yaml
+++ b/test/testConfig.yaml
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-OpenbaoAddresses:
+ServerAddresses:
   controller-0:
     host: "Openbao"
     port: 8200


### PR DESCRIPTION
Remove most of the branded references in comment, log and variable names.  This reduces the cost of code reuse
in change I0d7ff44d92bb6454101c6763bed29d9d8c92c136

Partial-bug: 2117422

Test Plan:
PASS  Unit test changes
PASS  Host-based openbao
PASS  K8s application openbao

Picked from starlingx/utilities commit 93dad4fe

Change-Id: I576af7808c7dbd00618d08ce7686303be27a3363