### PR TITLE
openbao-monitor: remove non-json output of health and init commands

### DIFF
--- a/commands/health.go
+++ b/commands/health.go
@@ -44,7 +44,6 @@ var healthCmd = &cobra.Command{
 			return fmt.Errorf("unable to marshal health check result: %v", err)
 		}
 		slog.Info(fmt.Sprintf("Health check command successful for host %v", args[0]))
-		fmt.Print("Health check successful. Result:\n")
 		fmt.Print(string(healthPrint))
 
 		return nil

--- a/commands/init.go
+++ b/commands/init.go
@@ -103,7 +103,6 @@ configurations.`,
 			return fmt.Errorf("Init failed with error: %v", err)
 		}
 		slog.Info(fmt.Sprintf("Init successful for host %v", args[0]))
-		fmt.Print("Init complete\n")
 		return nil
 	},
 	PersistentPostRunE: cleanCmd,


### PR DESCRIPTION
Remove the stdout from successful health and init commands.

The output of health command will be parsed by scripts.  The stdout for init will be extra and not properly formatted for pod logs.

Partial-bug: 2117422

Test Plan:
PASS  inspection of stdout/stderr for health and init commands.

Picked from starlingx/utilities commit a5c49d8e

Change-Id: I3ff8782399951eaf301fe60372058ade49349514