### PR TITLE
Openbao-monitor: Add store to k8s for init

### DIFF
--- a/commands/init.go
+++ b/commands/init.go
@@ -105,6 +105,22 @@ configurations.`,
 		slog.Info(fmt.Sprintf("Init successful for host %v", args[0]))
 		return nil
 	},
+	PostRunE: func(cmd *cobra.Command, args []string) error {
+		if useK8sConfig {
+			// create client config
+			config, err := getK8sConfig()
+			if err != nil {
+				return err
+			}
+
+			// Store only the token & key shard info gained from init
+			err = globalConfig.StoreSecretConfig(config)
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	},
 	PersistentPostRunE: cleanCmd,
 }
 

--- a/commands/root.go
+++ b/commands/root.go
@@ -101,7 +101,6 @@ func setupCmd(cmd *cobra.Command, args []string) error {
 
 func cleanCmd(cmd *cobra.Command, args []string) error {
 	slog.Debug("Running cleanup...")
-	// Write back to configs from file only
 	if !useK8sConfig {
 		configWriter, err := os.OpenFile(configFile, os.O_WRONLY|os.O_TRUNC, 0644)
 		if err != nil {

--- a/config/go.mod
+++ b/config/go.mod
@@ -13,6 +13,7 @@ toolchain go1.24.2
 require (
 	github.com/go-yaml/yaml v2.1.0+incompatible
 	github.com/openbao/openbao/api/v2 v2.2.0
+	k8s.io/api v0.33.0
 	k8s.io/apimachinery v0.33.0
 	k8s.io/client-go v0.33.0
 )
@@ -62,7 +63,6 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	k8s.io/api v0.33.0 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20250318190949-c8a335a9a2ff // indirect
 	k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738 // indirect


### PR DESCRIPTION
Adding a store to k8s option for tokens and key shards in the monitor config. This will only work if the useK8sConfigs option was enabled.

Test Plan:
PASS    The secrets are stored back after init in the k8s based openbao
server
PASS    The secrets are stored back after init in the host based openbao
server
PASS    The secrets are not erroneously stored in k8s secrets for
non-init operations in the k8s based openbao server

Story: 2011244
Task: 52697

Change-Id: Iac39a4391aae6713ae194850b37735d3efd385bd